### PR TITLE
Fix the behavior after registering as a new user

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,7 +13,9 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to root_url
+      log_in @user
+      flash[:success] = 'ユーザー登録が完了しました'
+      redirect_to @user
     else
       render 'new'
     end

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -2,7 +2,7 @@
     = render 'shared/error_messages', object: f.object
 
     .form-parts
-        = f.label :image, "プロフィール画像"
+        = f.label :image, "プロフィール画像（任意）"
         = f.file_field :image, accept: 'image/jpeg, image/png, image/gif'
 
     .form-parts

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -1,6 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe 'Users', type: :request do
+  subject { response }
+
+  describe 'POST #create' do
+    it 'add a user' do
+      post users_path,
+           params: { user: { name: 'john', email: 'john@example.com', password: 'password', password_confirmation: 'password' } }
+      expect(User.count).to eq 1
+      is_expected.to redirect_to user_path(User.first)
+      expect(is_logged_in?).to eq true
+    end
+  end
+
   describe 'DELETE #destroy' do
     before do
       @john = create(:john)
@@ -15,8 +27,8 @@ RSpec.describe 'Users', type: :request do
 
       it 'cannot delete a user' do
         delete user_path(@john)
-        expect(response).to redirect_to root_path
-        expect(User.count). to eq 2
+        is_expected.to redirect_to root_path
+        expect(User.count).to eq 2
       end
     end
   end

--- a/spec/system/users_signup_spec.rb
+++ b/spec/system/users_signup_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe 'UsersSignup', type: :system do
       fill_in 'パスワード（6文字以上）', with: 'password'
       fill_in '確認用パスワード', with: 'password'
       expect { click_button '登録する' }.to change(User, :count).by(1)
-      is_expected.to have_current_path root_path
+      is_expected.to have_current_path user_path(User.first)
+      is_expected.to have_css '.success-message'
     end
   end
 


### PR DESCRIPTION
新規ユーザー登録後は、その新規ユーザーでログインし、新規ユーザーの詳細ページにリダイレクトするように修正をしました。
それに伴い、テストの追加・修正も行いました。